### PR TITLE
Se agrega gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Compiled class files
+*.class
+
+# Jar files
+*.jar
+*.war
+*.ear
+
+# Log files
+*.log
+
+# Temp files
+*~
+*.swp
+*.bak
+*.tmp
+
+# IDE-specific files
+# Eclipse
+.classpath
+.project
+.settings/
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+# NetBeans
+nbproject/
+# VS Code
+.vscode/
+
+# Maven artifacts
+target/
+pom.xml.tag
+pom.xml.next
+pom.xml.bak
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.vm
+# Gradle artifacts
+.gradle/
+build/
+
+# Miscellaneous
+*.DS_Store # macOS
+Thumbs.db # Windows


### PR DESCRIPTION
Se añade gitignore y se remueven archivos de build, graddle y otros elementos de desarrollo redundantes.